### PR TITLE
SafeMoney/PTagged

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -423,7 +423,6 @@
         "hpc-coveralls": "hpc-coveralls",
         "nix-tools": "nix-tools",
         "nixpkgs": [
-          "haskell-nix",
           "nixpkgs-2111"
         ],
         "nixpkgs-2003": "nixpkgs-2003",

--- a/plutarch-safemoney/LICENSE
+++ b/plutarch-safemoney/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2021-2022 Ardana Labs
+Copyright (c) 2021-2022 Cardax B.V.
+Copyright (c) 2021-2022 Minswap Team
+Copyright (c) 2021-2022 Liqwid Labs
+Copyright (c) 2021-2022 Platonic.Systems
+Copyright (c) 2021-2022 MLabs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plutarch-safemoney/README.md
+++ b/plutarch-safemoney/README.md
@@ -1,0 +1,11 @@
+# `plutarch-safemoney`
+
+## What is this?
+
+Various types for dealing with assets in a type-safe way.
+
+## What can this do?
+
+## What can I do with this?
+
+The code is licensed under MIT; check the LICENSE file for details.

--- a/plutarch-safemoney/plutarch-safemoney.cabal
+++ b/plutarch-safemoney/plutarch-safemoney.cabal
@@ -50,10 +50,10 @@ library
   import:          lang
   exposed-modules:
     Plutarch.SafeMoney
+    Plutarch.SafeMoney.Exchange
+    Plutarch.SafeMoney.Tagged
 
   other-modules:
-    Plutarch.SafeMoney.Tagged
-    Plutarch.SafeMoney.Exchange
 
   build-depends:
     , base               >=4.14

--- a/plutarch-safemoney/plutarch-safemoney.cabal
+++ b/plutarch-safemoney/plutarch-safemoney.cabal
@@ -1,0 +1,70 @@
+cabal-version:      3.0
+name:               plutarch-safemoney
+version:            0.3
+author:             Emily Martins <emi@haskell.fyi>
+license:            MIT
+extra-source-files:
+  README.md
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    BangPatterns
+    BinaryLiterals
+    ConstraintKinds
+    DataKinds
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    DuplicateRecordFields
+    EmptyCase
+    FlexibleContexts
+    FlexibleInstances
+    GADTs
+    GeneralizedNewtypeDeriving
+    HexFloatLiterals
+    ImportQualifiedPost
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NumericUnderscores
+    OverloadedStrings
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+    TypeOperators
+    TypeSynonymInstances
+    UndecidableInstances
+    QualifiedDo
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns -Wredundant-constraints
+    -Wmissing-export-lists -Werror -Wincomplete-record-updates
+    -Wmissing-deriving-strategies
+
+library
+  import:          lang
+  exposed-modules:
+    Plutarch.SafeMoney
+
+  other-modules:
+    Plutarch.SafeMoney.Tagged
+    Plutarch.SafeMoney.Exchange
+
+  build-depends:
+    , base               >=4.14
+    , plutarch          ^>=1.1
+    , plutarch-numeric  ^>=1.0
+    , plutarch-extra    ^>=1.1
+
+    , tagged
+
+    , plutus-ledger-api
+    , plutus-tx
+    , plutus-core
+
+  hs-source-dirs:  src

--- a/plutarch-safemoney/src/Plutarch/SafeMoney.hs
+++ b/plutarch-safemoney/src/Plutarch/SafeMoney.hs
@@ -25,7 +25,9 @@ module Plutarch.SafeMoney (
 
   -- * Conversions
   pdiscreteValue,
+  pdiscreteValue',
   pvalueDiscrete,
+  pvalueDiscrete',
 ) where
 
 import Prelude hiding (Num (..))
@@ -40,9 +42,9 @@ import Plutarch.Prelude
 
 --------------------------------------------------------------------------------
 
-import Plutarch.Api.V1.Extra (passetClass, passetClassValueOf, psingletonValue)
+import Plutarch.Api.V1.Extra (PAssetClass, passetClass, passetClassValue, passetClassValueOf, psingletonValue)
 
-import Plutarch.SafeMoney.Tagged (PTagged (PTagged), Tagged (Tagged))
+import Plutarch.SafeMoney.Tagged (PTagged, Tagged (Tagged))
 import Plutarch.SafeMoney.Tagged qualified as Tagged
 
 type PDiscrete tag = PTagged tag PInteger
@@ -50,17 +52,28 @@ type PDense tag = PTagged tag PRational
 
 --------------------------------------------------------------------------------
 
-{- | Downcast a 'PValue' to a 'PDiscrete' unit, providing a witness of the 'AssetClass'.
+{- | Downcast a 'PValue' to a 'PDiscrete' unit, providing a witness of the 'PAssetClass'.
 
      @since 0.3
 -}
 pvalueDiscrete ::
   forall (tag :: Type) (s :: S).
+  Term s (PAssetClass :--> PValue :--> PDiscrete tag)
+pvalueDiscrete = phoistAcyclic $
+  plam $ \ac f ->
+    Tagged.ptag $ passetClassValueOf # f # ac
+
+{- | Downcast a 'PValue' to a 'PDiscrete' unit, providing a witness of the 'AssetClass', which gets inlined. If you use this 'AssetClass' twice, prefer 'pvalueDiscrete'.
+
+     @since 0.3
+-}
+pvalueDiscrete' ::
+  forall (tag :: Type) (s :: S).
   Tagged tag AssetClass ->
   Term s (PValue :--> PDiscrete tag)
-pvalueDiscrete (Tagged (AssetClass (cs, tn))) = phoistAcyclic $
+pvalueDiscrete' (Tagged (AssetClass (cs, tn))) = phoistAcyclic $
   plam $ \f ->
-    pcon . PTagged $ passetClassValueOf # f #$ passetClass # pconstant cs # pconstant tn
+    Tagged.ptag $ passetClassValueOf # f #$ passetClass # pconstant cs # pconstant tn
 
 {- | Get a 'PValue' from a 'PDiscrete', providing a witness of the 'AssetClass'.
      __NOTE__: `pdiscreteValue` after `pvalueDiscrete` is not a round-trip.
@@ -70,12 +83,28 @@ pvalueDiscrete (Tagged (AssetClass (cs, tn))) = phoistAcyclic $
 -}
 pdiscreteValue ::
   forall (tag :: Type) (s :: S).
+  Term s (PAssetClass :--> PDiscrete tag :--> PValue)
+pdiscreteValue = phoistAcyclic $
+  plam $ \ac p ->
+    passetClassValue
+      # ac
+      # Tagged.puntag p
+
+{- | Get a 'PValue' from a 'PDiscrete', providing a witness of the 'AssetClass'.
+     __NOTE__: `pdiscreteValue` after `pvalueDiscrete` is not a round-trip.
+     It filters for a particular tag.
+
+     If you use this 'AssetClass' twice, prefer 'pvalueDiscrete'.
+
+     @since 0.3
+-}
+pdiscreteValue' ::
+  forall (tag :: Type) (s :: S).
   Tagged tag AssetClass ->
   Term s (PDiscrete tag :--> PValue)
-pdiscreteValue (Tagged (AssetClass (cs, tn))) = phoistAcyclic $
-  plam $ \f -> pmatch f $ \case
-    PTagged p ->
-      psingletonValue
-        # pconstant cs
-        # pconstant tn
-        # p
+pdiscreteValue' (Tagged (AssetClass (cs, tn))) = phoistAcyclic $
+  plam $ \p ->
+    psingletonValue
+      # pconstant cs
+      # pconstant tn
+      # Tagged.puntag p

--- a/plutarch-safemoney/src/Plutarch/SafeMoney.hs
+++ b/plutarch-safemoney/src/Plutarch/SafeMoney.hs
@@ -9,8 +9,17 @@ Phantom-type tagged types for handling assets in Plutus.
 -}
 module Plutarch.SafeMoney (
   -- * Tagged data types
-  Tagged.PTagged (..),
+  Tagged.PTagged,
+  Tagged.ptag,
+  Tagged.puntag,
+  Tagged.pretag,
+
+  -- * Reexports from "Data.Tagged"
   Tagged.Tagged (..),
+  Tagged.untag,
+  Tagged.retag,
+
+  -- * Numeric type aliases
   PDiscrete,
   PDense,
 
@@ -41,7 +50,10 @@ type PDense tag = PTagged tag PRational
 
 --------------------------------------------------------------------------------
 
--- | Downcast a 'PValue' to a 'PDiscrete' unit, providing a witness of the 'AssetClass'.
+{- | Downcast a 'PValue' to a 'PDiscrete' unit, providing a witness of the 'AssetClass'.
+
+     @since 0.3
+-}
 pvalueDiscrete ::
   forall (tag :: Type) (s :: S).
   Tagged tag AssetClass ->
@@ -53,6 +65,8 @@ pvalueDiscrete (Tagged (AssetClass (cs, tn))) = phoistAcyclic $
 {- | Get a 'PValue' from a 'PDiscrete', providing a witness of the 'AssetClass'.
      __NOTE__: `pdiscreteValue` after `pvalueDiscrete` is not a round-trip.
      It filters for a particular tag.
+
+     @since 0.3
 -}
 pdiscreteValue ::
   forall (tag :: Type) (s :: S).

--- a/plutarch-safemoney/src/Plutarch/SafeMoney.hs
+++ b/plutarch-safemoney/src/Plutarch/SafeMoney.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE PolyKinds #-}
+
+{- |
+Module     : Plutarch.SafeMoney
+Maintainer : emi@haskell.fyi
+Description: Phantom-type tagged types for handling assets in Plutus.
+
+Phantom-type tagged types for handling assets in Plutus.
+-}
+module Plutarch.SafeMoney (
+  -- * Tagged data types
+  Tagged.PTagged (..),
+  Tagged.Tagged (..),
+  PDiscrete,
+  PDense,
+
+  -- * Conversions
+  pdiscreteValue,
+  pvalueDiscrete,
+) where
+
+import Prelude hiding (Num (..))
+
+--------------------------------------------------------------------------------
+
+import Plutus.V1.Ledger.Value (AssetClass (AssetClass))
+
+import Plutarch.Api.V1 (PValue)
+import Plutarch.Builtin ()
+import Plutarch.Prelude
+
+--------------------------------------------------------------------------------
+
+import Plutarch.Api.V1.Extra (passetClass, passetClassValueOf, psingletonValue)
+
+import Plutarch.SafeMoney.Tagged (PTagged (PTagged), Tagged (Tagged))
+import Plutarch.SafeMoney.Tagged qualified as Tagged
+
+type PDiscrete tag = PTagged tag PInteger
+type PDense tag = PTagged tag PRational
+
+--------------------------------------------------------------------------------
+
+-- | Downcast a 'PValue' to a 'PDiscrete' unit, providing a witness of the 'AssetClass'.
+pvalueDiscrete ::
+  forall (tag :: Type) (s :: S).
+  Tagged tag AssetClass ->
+  Term s (PValue :--> PDiscrete tag)
+pvalueDiscrete (Tagged (AssetClass (cs, tn))) = phoistAcyclic $
+  plam $ \f ->
+    pcon . PTagged $ passetClassValueOf # f #$ passetClass # pconstant cs # pconstant tn
+
+{- | Get a 'PValue' from a 'PDiscrete', providing a witness of the 'AssetClass'.
+     __NOTE__: `pdiscreteValue` after `pvalueDiscrete` is not a round-trip.
+     It filters for a particular tag.
+-}
+pdiscreteValue ::
+  forall (tag :: Type) (s :: S).
+  Tagged tag AssetClass ->
+  Term s (PDiscrete tag :--> PValue)
+pdiscreteValue (Tagged (AssetClass (cs, tn))) = phoistAcyclic $
+  plam $ \f -> pmatch f $ \case
+    PTagged p ->
+      psingletonValue
+        # pconstant cs
+        # pconstant tn
+        # p

--- a/plutarch-safemoney/src/Plutarch/SafeMoney/Exchange.hs
+++ b/plutarch-safemoney/src/Plutarch/SafeMoney/Exchange.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Module     : Plutarch.SafeMoney.Exchange
+Maintainer : emi@haskell.fyi
+Description: Phantom-type tagged types for handling assets in Plutus.
+
+Phantom-type tagged types for handling assets in Plutus.
+-}
+module Plutarch.SafeMoney.Exchange (
+  (:>),
+  exchange,
+  exchangeFrom,
+) where
+
+import Prelude hiding (Fractional (..), Num (..))
+
+import Plutarch.Numeric
+import Plutarch.Prelude
+import Plutarch.SafeMoney.Tagged (PTagged (..), pretag, ptag, puntag)
+
+{- | Represents an exchange from a to b.
+
+     Let's say 1.00 ADA is worth 2.00 USD, then @ADA ':>' USD@ ought to be represented as 2.00.
+-}
+data (:>) a b
+
+-- | Create an exchange given an example relation.
+exchange :: Term s (PTagged a PInteger :--> PTagged b PNZNatural :--> PTagged (a :> b) (PRatio PInteger))
+exchange =
+  phoistAcyclic $
+    plam $ \a b ->
+      ptag $ pconRatio (puntag a) (puntag b)
+
+-- | Exchange from 'a' to 'b' given the exchange rate.
+exchangeFrom ::
+  forall (s :: S) a b.
+  Term
+    s
+    ( PTagged (a :> b) (PRatio PInteger)
+        :--> PTagged a (PRatio PInteger)
+        :--> PTagged b (PRatio PInteger)
+    )
+exchangeFrom =
+  phoistAcyclic $
+    plam $ \ex x -> pretag ex * pretag x

--- a/plutarch-safemoney/src/Plutarch/SafeMoney/Tagged.hs
+++ b/plutarch-safemoney/src/Plutarch/SafeMoney/Tagged.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE ViewPatterns #-}
+
+{- |
+Module     : Plutarch.SafeMoney.Tagged
+Maintainer : emi@haskell.fyi
+Description: On-chain Tagged equivalent.
+
+On-chain Tagged equivalent. "Data.Tagged" has (something like):
+@
+data 'Tagged' t a = 'Tagged' a
+@
+
+In order for it to exist on-chain,
+we can simply make it a 'PlutusType' by adding @s :: 'S'@:
+@
+data PTagged t a (s :: S) = PTagged (Term s a)
+@
+
+Following this, it's possible to rewrite a number of
+the "Data.Tagged" utils in terms of Plutarch code.
+-}
+module Plutarch.SafeMoney.Tagged (
+  module Data.Tagged,
+  PTagged (..),
+  pretag,
+  puntag,
+  ptag,
+) where
+
+import Data.Tagged
+import Plutarch.Numeric
+import Plutarch.Prelude
+import Plutarch.Unsafe (punsafeCoerce)
+import Prelude hiding (Fractional (..), Num (..), quot, rem)
+
+--------------------------------------------------------------------------------
+
+{- | A Plutarch-level 'Tagged'.
+
+     @since 0.3
+-}
+newtype PTagged tag (underlying :: PType) (s :: S)
+  = PTagged (Term s underlying)
+  deriving
+    (PlutusType, PIsData, PEq, POrd)
+    via (DerivePNewtype (PTagged tag underlying) underlying)
+
+{- | Change the tag on a 'PTagged'. Plutarch-level equivalent of 'retag'.
+
+     @since 0.3
+-}
+pretag :: forall t' t a s. Term s (PTagged t a) -> Term s (PTagged t' a)
+pretag = punsafeCoerce
+
+{- | Strip the tag off a 'PTagged'. Plutarch-level equivalent of 'untag'.
+
+     @since 0.3
+-}
+puntag :: Term s (PTagged t a) -> Term s a
+puntag = punsafeCoerce
+
+{- | Smart constructor for 'PTagged'.
+     Plutarch-level equivalent of 'Tagged' constructor.
+     The reason this exists is because @'pcon' ('PTagged' @tag x)@ is longer
+     and less readable than @'ptag' @tag x@.
+
+     @since 0.3
+-}
+ptag :: forall t a s. Term s a -> Term s (PTagged t a)
+ptag = punsafeCoerce
+
+--------------------------------------------------------------------------------
+-- Safely lift any Tagged with a closed operation.
+
+-- | Internal helper function for instances.
+liftTagged0 ::
+  Term s underlying ->
+  Term s (PTagged tag underlying)
+liftTagged0 a =
+  pcon (PTagged a)
+
+-- | Internal helper function for instances.
+liftTagged1 ::
+  (Term s underlying -> Term s underlying) ->
+  Term s (PTagged tag underlying) ->
+  Term s (PTagged tag underlying)
+liftTagged1 f x =
+  pmatch x $ \(PTagged x') -> pcon . PTagged . f $ x'
+
+-- | Internal helper function for instances.
+liftTagged2 ::
+  (Term s underlying -> Term s underlying -> Term s underlying) ->
+  Term s (PTagged tag underlying) ->
+  Term s (PTagged tag underlying) ->
+  Term s (PTagged tag underlying)
+liftTagged2 f x y =
+  pmatch x $ \(PTagged x') ->
+    pmatch y $ \(PTagged y') ->
+      pcon . PTagged $ x' `f` y'
+
+instance
+  forall tag (underlying :: PType) (s :: S).
+  AdditiveSemigroup (Term s underlying) =>
+  AdditiveSemigroup (Term s (PTagged tag underlying))
+  where
+  (+) = liftTagged2 (+)
+
+instance
+  forall tag (underlying :: PType) (s :: S).
+  AdditiveMonoid (Term s underlying) =>
+  AdditiveMonoid (Term s (PTagged tag underlying))
+  where
+  zero = liftTagged0 zero
+
+instance
+  forall tag (underlying :: PType) (s :: S).
+  AdditiveGroup (Term s underlying) =>
+  AdditiveGroup (Term s (PTagged tag underlying))
+  where
+  (-) = liftTagged2 (-)
+  negate = liftTagged1 negate
+
+instance
+  forall tag (underlying :: PType) (s :: S).
+  AdditiveCMM (Term s underlying) =>
+  AdditiveCMM (Term s (PTagged tag underlying))
+  where
+  (^-) = liftTagged2 (^-)
+
+instance
+  forall tag (underlying :: PType) (s :: S).
+  MultiplicativeSemigroup (Term s underlying) =>
+  MultiplicativeSemigroup (Term s (PTagged tag underlying))
+  where
+  (*) = liftTagged2 (*)
+
+instance
+  forall tag (underlying :: PType) (s :: S).
+  MultiplicativeMonoid (Term s underlying) =>
+  MultiplicativeMonoid (Term s (PTagged tag underlying))
+  where
+  one = ptag one
+  abs = ptag . abs . puntag
+  signum = ptag . signum . puntag
+
+instance
+  forall tag (underlying :: PType) (s :: S).
+  Distributive (Term s underlying) =>
+  Distributive (Term s (PTagged tag underlying))
+  where
+  fromNZNatural = pcon . PTagged . fromNZNatural
+
+instance
+  forall tag (a :: PType) (nz :: PType) (s :: S).
+  Euclidean (Term s a) (Term s nz) =>
+  Euclidean (Term s (PTagged tag a)) (Term s (PTagged tag nz))
+  where
+  (puntag -> a) +^ (puntag -> nz) = ptag (a +^ nz)
+  (puntag -> a) *^ (puntag -> nz) = ptag (a *^ nz)
+  (puntag -> a) `quot` (puntag -> nz) = ptag (a `quot` nz)
+  (puntag -> a) `rem` (puntag -> nz) = ptag (a `rem` nz)
+  fromNatural = ptag . fromNatural
+
+instance
+  forall tag (a :: PType) (nz :: PType) (s :: S).
+  Divisible (Term s a) (Term s nz) =>
+  Divisible (Term s (PTagged tag a)) (Term s (PTagged tag nz))
+  where
+  reciprocal (puntag -> nz) = ptag (reciprocal nz)
+  (puntag -> a) / (puntag -> nz) = ptag (a / nz)

--- a/plutarch-safemoney/src/Plutarch/SafeMoney/Tagged.hs
+++ b/plutarch-safemoney/src/Plutarch/SafeMoney/Tagged.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 {- |
 Module     : Plutarch.SafeMoney.Tagged
@@ -31,7 +32,25 @@ import Data.Tagged
 import Plutarch.Numeric
 import Plutarch.Prelude
 import Plutarch.Unsafe (punsafeCoerce)
+import PlutusTx qualified
 import Prelude hiding (Fractional (..), Num (..), quot, rem)
+
+--------------------------------------------------------------------------------
+-- Data.Tagged orphans.
+-- The only alternative way to solve this is to use our own version of 'Tagged'.
+-- Even Tagged from "plutus-ledger-api" doesn't have ToData instances.
+
+deriving newtype instance
+  PlutusTx.ToData underlying =>
+  PlutusTx.ToData (Tagged tag underlying)
+
+deriving newtype instance
+  PlutusTx.FromData underlying =>
+  PlutusTx.FromData (Tagged tag underlying)
+
+deriving newtype instance
+  PlutusTx.UnsafeFromData underlying =>
+  PlutusTx.UnsafeFromData (Tagged tag underlying)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
I've boiled this rendition of `SafeMoney` down to its conclusion.

Summary:
- Zero-cost plutarch level version of [Data.Tagged](https://hackage.haskell.org/package/tagged-0.8.6.1/docs/Data-Tagged.html).
- A number of `plutarch-numeric` instances over it.


Needing of work:
- `Plutarch.SafeMoney.Exchange`. This is really just a stub for what it could look like, more than an actually usable module. cc: @t1lde


Needing of review:
- Interactions with `plutarch-numeric`. plutarch-numeric is quite a strain on ergonomics, and for good reasons, so a little bit of work needs to be done figuring out how to get things to fit nicely together. cc: @kozross

